### PR TITLE
Erroneous data checks for Group and Membership data

### DIFF
--- a/src/main/java/server/database/model/Group.java
+++ b/src/main/java/server/database/model/Group.java
@@ -24,7 +24,7 @@ public class Group {
         return groupName;
     }
 
-    public int getParent() { return parent; }
+    public Integer getParent() { return parent; }
 
     public void setGroupID(int groupID) {
         this.groupID = groupID;


### PR DESCRIPTION
Added erroneous data checks for group and membership files as per the assignment document.
- Non-existent "foreign keys" (memberships.json: userID, groupID | groups.json: parentID)
- Preventing circular parent-child definitions (parent groupID < child groupID)
- Invalid types
- Empty Strings